### PR TITLE
Fix date and datetime conversion for numpy scalars

### DIFF
--- a/src/cadati/jd_date.py
+++ b/src/cadati/jd_date.py
@@ -5,13 +5,12 @@
 Module provides function to convert julian dates into other date formats.
 """
 
-
 import datetime
+
 import numpy as np
 
-from cadati.np_date import dt2cal
 from cadati.check_date import is_leap_year
-
+from cadati.np_date import dt2cal
 
 # leap year
 days_past = np.array([0, 31, 60, 91, 121, 152, 182, 213,
@@ -198,9 +197,7 @@ def julian2date(jd, return_doy=False, doy_leap_year=True):
     min_julian = 2299160
     max_julian = 1827933925
 
-    is_single_value = False
-    if type(jd) in (float, int):
-        is_single_value = True
+    is_single_value = np.isscalar(jd)
 
     julian = np.atleast_1d(np.array(jd, dtype=float))
 
@@ -270,7 +267,7 @@ def jd2dt(jd):
     dt : numpy.datetime64[ms]
         Array of dates in datetime64[ms] format.
     """
-    dt = ((((jd - 2440587.5)*24.*3600.*1e6).astype('datetime64[us]')
+    dt = ((((jd - 2440587.5) * 24. * 3600. * 1e6).astype('datetime64[us]')
            + np.timedelta64(500, 'us')).astype('datetime64[ms]'))
 
     return dt

--- a/tests/test_date_conversion.py
+++ b/tests/test_date_conversion.py
@@ -21,7 +21,6 @@ from cadati.jd_date import julian2datetime, julian2date, julday, caldat
 class TestDateFunctions(unittest.TestCase):
 
     def setUp(self):
-
         years = np.arange(2000, 2012)
         months = np.arange(1, 13)
         days = np.arange(1, 13)
@@ -179,6 +178,22 @@ def test_julian2date():
     assert ms == 807989
 
 
+def test_julian2date_numpy_scalar():
+    """
+    Test julian2date numpy scalar.
+    """
+    year, month, day, hour, minute, second, ms = julian2date(np.float64(2457533.9306828701))
+
+    assert type(year) == int
+    assert year == 2016
+    assert month == 5
+    assert day == 25
+    assert hour == 10
+    assert minute == 20
+    assert second == 10
+    assert ms == 999976
+
+
 def test_julian2date_single_array():
     """
     Test julian2date single array.
@@ -225,6 +240,15 @@ def test_julian2datetime():
     assert dt == dt_should
 
 
+def test_julian2datetime_numpy_scalar():
+    """
+    Test julian2datetime for numpy scalar.
+    """
+    dt = julian2datetime(np.float64(2457533.9306828701))
+    dt_should = datetime.datetime(2016, 5, 25, 10, 20, 10, 999976)
+    assert np.all(dt == dt_should)
+
+
 def test_julian2datetime_single_array():
     """
     Test julian2datetime for single array.
@@ -248,6 +272,7 @@ def test_julian2datetime_array():
     assert type(dt) == np.ndarray
     assert np.all(dt == dt_should)
 
+
 def test_dt2days():
     """
     Test dt2days conversion.
@@ -256,15 +281,17 @@ def test_dt2days():
 
     assert dt == days2dt(dt2days(dt))
 
+
 def test_dt2days_array():
     """
     Test dt2days array conversion.
     """
     dt = np.arange('2021-09-24 08:00:00',
                    '2021-09-24 11:20:00',
-                    np.timedelta64(20,'m'), dtype='datetime64')
+                   np.timedelta64(20, 'm'), dtype='datetime64')
 
     assert np.all(dt == days2dt(dt2days(dt)))
+
 
 def test_days2dt():
     """
@@ -273,6 +300,7 @@ def test_days2dt():
     days = 44227.12121
 
     assert days == dt2days(days2dt(days))
+
 
 def test_days2dt_array():
     """


### PR DESCRIPTION
I recently ran into the problem that juliand2datetime would crash when juliand2datetime is invoked with a numpy scalar.

Steps to reproduce:
```
julian2datetime(np.float64(2457533.9306828701))
```

This is because julian2date behaves like it would receive an array type and returns arrays which julian2datetime is not expecting.

I propose to harmonise the behaviour of julian2date so it behaves the same for all scalar types no matter the format.

Tests have been added to regress and document this behaviour.